### PR TITLE
Fixes #4

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -35,5 +35,6 @@
     "architectury": ">=17.0.6",
     "fabric-api": "*",
     "yet_another_config_lib_v3": ">=3.7.1"
-  }
+  },
+  "accesswidener": "enc_vanilla.accesswidener"
 }


### PR DESCRIPTION
The accesswidener needs to be declared in the fabric.mod.json for fabric to handle transformed class correctly.